### PR TITLE
Use `extensionPack` instead of `extensionDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "vscode": "^1.12.0"
   },
-  "extensionDependencies": [
+  "extensionPack": [
     "christian-kohler.npm-intellisense",
     "christian-kohler.path-intellisense",
     "dariofuzinato.vue-peek",


### PR DESCRIPTION
From release v1.26, defining an Extension Pack now uses a new property called `extensionPack` instead of `extensionDependencies` in package.json. This is because extensionDependencies is mainly used to define functional dependencies and an Extension Pack should not have any functional dependencies with its bundled extensions and they should be manageable independent of the pack. 

So please use `extensionPack` property for defining the pack.

For more details refer to [Release notes](https://code.visualstudio.com/updates/v1_26#_extension-packs-revisited)