### PR TITLE
fix: remove deprecated extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "tombonnike.vscode-status-bar-format-toggle",
-    "eg2.vscode-npm-script",
     "christian-kohler.npm-intellisense",
     "VisualStudioExptTeam.vscodeintellicode"
   ],


### PR DESCRIPTION
From the maintainer:

❗IMPORTANT: This extension has been deprecated. Support for running npm scripts is now provided by VS Code. You can run npm scripts as tasks using task auto detection or from the npm scripts explorer.
---

As seen here:
https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script