### PR TITLE
remove `ZixuanChen.vitest-explorer` in favor of `vitest.explorer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "Nuxtr.nuxtr-vscode",
     "sdras.vue-vscode-snippets",
     "antfu.vite",
-    "ZixuanChen.vitest-explorer",
+    "vitest.explorer",
     "xabikos.javascriptsnippets",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",


### PR DESCRIPTION
fix #17

I also came across deprecation warning.
`ZixuanChen.vitest-explorer` is deprecated in favor of `vitest.explorer`.

thank you for great extension pack !
